### PR TITLE
update schul-cloud-resources-api-v1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ py==1.4.34                # via pytest
 pytest==3.1.2
 python-dateutil==2.6.0    # via schul-cloud-resources-api-v1
 requests==2.18.1
-schul-cloud-resources-api-v1==1.0.0.277
+schul-cloud-resources-api-v1==1.0.0.326
 six==1.10.0               # via python-dateutil, schul-cloud-resources-api-v1
 urllib3==1.21.1           # via requests, schul-cloud-resources-api-v1


### PR DESCRIPTION
Errors like this may be because of an old version
https://travis-ci.org/schul-cloud/schul_cloud_resources_server_tests/jobs/322657285